### PR TITLE
Ensure Go parity for core and engine fixtures

### DIFF
--- a/test-cases/lithos-gotmpl-core.json
+++ b/test-cases/lithos-gotmpl-core.json
@@ -89,7 +89,7 @@
       "case": "slice",
       "repo": "https://github.com/golang/go"
     },
-    "template": "{{slice \"gopher\" \"1\" \"3\"}}",
+    "template": "{{slice \"gopher\" 1 3}}",
     "expected": "op"
   },
   {
@@ -130,6 +130,7 @@
       "repo": "https://github.com/golang/go"
     },
     "template": "{{call \"print\" \"Hello\"}}",
-    "expected": "Hello"
+    "expected": "Hello",
+    "skip_go": true
   }
 ]


### PR DESCRIPTION
## Summary
- extend the sprig compatibility harness to replay the core and engine JSON fixtures through the Go oracle before asserting the Rust results
- add a `-sprig` switch to the Go sanity runner so template-only suites can execute without the Sprig helpers
- tweak the core test fixtures to match Go behaviour, including skipping the string-based call case when comparing against the oracle

## Testing
- cargo test --package lithos-sprig --test compat
- cargo test --package lithos-gotmpl-core --test test_cases

------
https://chatgpt.com/codex/tasks/task_e_6907637f5618832581f9337b1b4d06a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--sprig` command-line flag (default enabled) to control inclusion of Sprig helper functions in template evaluation.

* **Tests**
  * Enhanced template validation infrastructure with fixture-driven test verification.
  * Refactored test helpers for improved organization and code reuse.

* **Bug Fixes**
  * Corrected template syntax in test cases to use proper numeric indices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->