### PR TITLE
Refactor go-sanity orchestration and argument coercion

### DIFF
--- a/go-sanity/main_test.go
+++ b/go-sanity/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCoerceNumberArgJSONInt(t *testing.T) {
+	target := reflect.TypeOf(int(0))
+	val, handled, err := coerceNumberArg(json.Number("42"), target)
+	if !handled {
+		t.Fatalf("expected strategy to handle json.Number input")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := val.Int(); got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}
+
+func TestCoerceNumberArgJSONInvalidTarget(t *testing.T) {
+	target := reflect.TypeOf(true)
+	_, handled, err := coerceNumberArg(json.Number("1"), target)
+	if !handled {
+		t.Fatalf("expected strategy to handle json.Number input")
+	}
+	if err == nil {
+		t.Fatalf("expected error for incompatible target type")
+	}
+}
+
+func TestConvertPrimitiveAssignable(t *testing.T) {
+	val, ok := convertPrimitive(reflect.ValueOf("hello"), reflect.TypeOf(""))
+	if !ok {
+		t.Fatalf("expected assignable value to succeed")
+	}
+	if val.Interface() != "hello" {
+		t.Fatalf("unexpected value: %v", val.Interface())
+	}
+}
+
+func TestConvertPrimitiveConvertible(t *testing.T) {
+	val, ok := convertPrimitive(reflect.ValueOf(int32(7)), reflect.TypeOf(int64(0)))
+	if !ok {
+		t.Fatalf("expected convertible value to succeed")
+	}
+	if got := val.Int(); got != 7 {
+		t.Fatalf("expected 7, got %d", got)
+	}
+}
+
+func TestConvertPrimitiveNotConvertible(t *testing.T) {
+	if _, ok := convertPrimitive(reflect.ValueOf(struct{}{}), reflect.TypeOf("")); ok {
+		t.Fatalf("expected conversion to fail for incompatible types")
+	}
+}


### PR DESCRIPTION
## Summary
- add a `run` entry point plus `evaluateCase`/`collectErrors` helpers to separate IO from evaluation logic
- break argument preparation into small coercion strategies, including explicit primitive and number handlers
- add unit tests that exercise the new coercion helpers to protect conversion semantics

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_69076f973d408325bdcd1dd609fc6466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and collection throughout evaluation pipeline, with errors now aggregated into output results.

* **New Features**
  * Enhanced JSON output formatting with improved pretty-print support.

* **Tests**
  * Added comprehensive test coverage for numeric type coercion and primitive type conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->