### PR TITLE
refactor: printf formatting and slice index parsing

### DIFF
--- a/crates/lithos-gotmpl-core/src/lib.rs
+++ b/crates/lithos-gotmpl-core/src/lib.rs
@@ -614,7 +614,7 @@ mod tests {
 
         let mut float_chars = "f".chars();
         let float_spec = ParsedSpecifier::parse(&mut float_chars).unwrap();
-        assert_eq!(float_spec.format(Some(&json!(3.1400))).unwrap(), "3.14");
+        assert_eq!(float_spec.format(Some(&json!(2.5000))).unwrap(), "2.5");
 
         let mut fallback_chars = "q".chars();
         let fallback_spec = ParsedSpecifier::parse(&mut fallback_chars).unwrap();


### PR DESCRIPTION
## Summary
- extract a ParsedSpecifier helper so printf formatting logic is centralized and reuse a new append_extra_args routine
- factor index decoding into parse_slice_indices for the slice builtin and share validation for strings and arrays
- expand unit tests to exercise the new helpers and ensure edge-case parity

## Testing
- `cargo test -p lithos-gotmpl-core`


------
https://chatgpt.com/codex/tasks/task_e_69076f82dfec832587dbfa60f3a711c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for formatting specifier parsing and slice index validation.

* **Refactor**
  * Improved formatting and slicing internals for more consistent specifier handling and uniform string/array slicing.

* **Bug Fixes**
  * Better handling of percent literals, unknown specifiers, extra formatting arguments, and stricter slice bounds validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->