### PR TITLE
Add Sprig helper fixtures and align helper semantics

### DIFF
--- a/crates/lithos-sprig/src/functions/lists.rs
+++ b/crates/lithos-sprig/src/functions/lists.rs
@@ -60,11 +60,10 @@ pub fn append(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error> {
 }
 
 pub fn prepend(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error> {
-    expect_min_args("prepend", args, 2)?;
-    let list = expect_array("prepend", &args[0], 1)?;
-    let mut prefix: Vec<Value> = args[1..].to_vec();
-    prefix.extend(list);
-    Ok(Value::Array(prefix))
+    expect_exact_args("prepend", args, 2)?;
+    let mut list = expect_array("prepend", &args[0], 1)?;
+    list.insert(0, args[1].clone());
+    Ok(Value::Array(list))
 }
 
 pub fn concat(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error> {

--- a/crates/lithos-sprig/src/functions/string_slice.rs
+++ b/crates/lithos-sprig/src/functions/string_slice.rs
@@ -39,13 +39,13 @@ pub fn split_map(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error>
 pub fn splitn(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error> {
     expect_exact_args("splitn", args, 3)?;
     let sep = expect_string("splitn", &args[0], 1)?;
-    let text = expect_string("splitn", &args[1], 2)?;
-    let count = super::expect_usize("splitn", &args[2], 3)?;
-    Ok(Value::Array(
-        text.splitn(count, &sep)
-            .map(|s| Value::String(s.to_string()))
-            .collect(),
-    ))
+    let count = super::expect_usize("splitn", &args[1], 2)?;
+    let text = expect_string("splitn", &args[2], 3)?;
+    let mut map = Map::new();
+    for (idx, part) in text.splitn(count, &sep).enumerate() {
+        map.insert(format!("_{idx}"), Value::String(part.to_string()));
+    }
+    Ok(Value::Object(map))
 }
 
 pub fn join(_ctx: &mut EvalContext, args: &[Value]) -> Result<Value, Error> {
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn splitn_truncates_to_requested_segments() {
         let mut ctx = ctx();
-        let out = splitn(&mut ctx, &[json!(","), json!("a,b,c"), json!(2)]).unwrap();
-        assert_eq!(out, json!(["a", "b,c"]));
+        let out = splitn(&mut ctx, &[json!(","), json!(2), json!("a,b,c")]).unwrap();
+        assert_eq!(out, json!({"_0": "a", "_1": "b,c"}));
     }
 }

--- a/crates/lithos-sprig/tests/coverage.rs
+++ b/crates/lithos-sprig/tests/coverage.rs
@@ -26,10 +26,7 @@ fn every_registered_helper_has_fixture() {
     let registered: BTreeSet<String> = sprig_registry.function_names().into_iter().collect();
 
     let covered = collect_fixture_helpers(&sprig_registry, test_cases_dir());
-    let missing: Vec<String> = registered
-        .difference(&covered)
-        .cloned()
-        .collect();
+    let missing: Vec<String> = registered.difference(&covered).cloned().collect();
 
     assert!(
         missing.is_empty(),
@@ -38,7 +35,10 @@ fn every_registered_helper_has_fixture() {
     );
 }
 
-fn collect_fixture_helpers(registry: &lithos_gotmpl_core::FunctionRegistry, root: PathBuf) -> BTreeSet<String> {
+fn collect_fixture_helpers(
+    registry: &lithos_gotmpl_core::FunctionRegistry,
+    root: PathBuf,
+) -> BTreeSet<String> {
     let mut covered = BTreeSet::new();
     let combined_registry = sprig_functions();
 
@@ -73,9 +73,16 @@ fn collect_fixture_helpers(registry: &lithos_gotmpl_core::FunctionRegistry, root
                 let template_path = entry.path().join("input.tmpl");
                 if template_path.exists() {
                     let name = entry.file_name().to_string_lossy().into_owned();
-                    let source = fs::read_to_string(&template_path)
-                        .unwrap_or_else(|err| panic!("failed to read {}: {err}", template_path.display()));
-                    collect_from_template(registry, &combined_registry, &name, &source, &mut covered);
+                    let source = fs::read_to_string(&template_path).unwrap_or_else(|err| {
+                        panic!("failed to read {}: {err}", template_path.display())
+                    });
+                    collect_from_template(
+                        registry,
+                        &combined_registry,
+                        &name,
+                        &source,
+                        &mut covered,
+                    );
                 }
             }
         }
@@ -99,7 +106,9 @@ fn collect_from_template(
         .unwrap_or_else(|err| panic!("failed to parse template {name}: {err}"));
     let analysis = template.analyze();
     for call in analysis.functions {
-        if matches!(call.source, FunctionSource::Registered) && sprig_registry.get(&call.name).is_some() {
+        if matches!(call.source, FunctionSource::Registered)
+            && sprig_registry.get(&call.name).is_some()
+        {
             covered.insert(call.name);
         }
     }

--- a/test-cases/lithos-sprig.json
+++ b/test-cases/lithos-sprig.json
@@ -50,6 +50,18 @@
     "expected": "hello sprig"
   },
   {
+    "name": "title-basic",
+    "function": "title",
+    "args": [
+      "hello sprig helpers"
+    ],
+    "template": "{{ title .text }}",
+    "data": {
+      "text": "hello sprig helpers"
+    },
+    "expected": "Hello Sprig Helpers"
+  },
+  {
     "name": "trim-whitespace",
     "function": "trim",
     "args": [
@@ -60,6 +72,16 @@
       "text": "  padded  \n"
     },
     "expected": "padded"
+  },
+  {
+    "name": "trimall-cutset",
+    "function": "trimAll",
+    "args": [
+      "-:",
+      "-:value:-"
+    ],
+    "template": "{{ trimAll \"-:\" \"-:value:-\" }}",
+    "expected": "value"
   },
   {
     "name": "contains-hit",
@@ -130,6 +152,11 @@
     "expected": "true"
   },
   {
+    "name": "fail-conditional",
+    "template": "{{ if false }}{{ fail \"boom\" }}{{ end }}",
+    "expected": ""
+  },
+  {
     "name": "trimprefix-basic",
     "function": "trimPrefix",
     "args": [
@@ -140,6 +167,16 @@
     "expected": "pher"
   },
   {
+    "name": "hasprefix-basic",
+    "function": "hasPrefix",
+    "args": [
+      "go",
+      "gopher"
+    ],
+    "template": "{{ hasPrefix \"go\" \"gopher\" }}",
+    "expected": "true"
+  },
+  {
     "name": "hassuffix-basic",
     "function": "hasSuffix",
     "args": [
@@ -148,6 +185,16 @@
     ],
     "template": "{{ hasSuffix \".rs\" \"main.rs\" }}",
     "expected": "true"
+  },
+  {
+    "name": "trimsuffix-basic",
+    "function": "trimSuffix",
+    "args": [
+      ".rs",
+      "main.rs"
+    ],
+    "template": "{{ trimSuffix \".rs\" \"main.rs\" }}",
+    "expected": "main"
   },
   {
     "name": "replace-basic",
@@ -169,6 +216,27 @@
     ],
     "template": "{{ join \":\" (splitList \",\" \"a,b,c\") }}",
     "expected": "a:b:c"
+  },
+  {
+    "name": "split-map",
+    "function": "split",
+    "args": [
+      ",",
+      "a,b,c"
+    ],
+    "template": "{{ toJson (split \",\" \"a,b,c\") }}",
+    "expected": "{\"_0\":\"a\",\"_1\":\"b\",\"_2\":\"c\"}"
+  },
+  {
+    "name": "splitn-limit",
+    "function": "splitn",
+    "args": [
+      ",",
+      2,
+      "a,b,c"
+    ],
+    "template": "{{ toJson (splitn \",\" 2 \"a,b,c\") }}",
+    "expected": "{\"_0\":\"a\",\"_1\":\"b,c\"}"
   },
   {
     "name": "join-basic",
@@ -196,6 +264,58 @@
     "expected": "abc"
   },
   {
+    "name": "first-basic",
+    "function": "first",
+    "args": [
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "template": "{{ first (list 1 2 3) }}",
+    "expected": "1"
+  },
+  {
+    "name": "last-basic",
+    "function": "last",
+    "args": [
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "template": "{{ last (list 1 2 3) }}",
+    "expected": "3"
+  },
+  {
+    "name": "rest-basic",
+    "function": "rest",
+    "args": [
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "template": "{{ toJson (rest (list 1 2 3)) }}",
+    "expected": "[2,3]"
+  },
+  {
+    "name": "initial-basic",
+    "function": "initial",
+    "args": [
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "template": "{{ toJson (initial (list 1 2 3)) }}",
+    "expected": "[1,2]"
+  },
+  {
     "name": "append-basic",
     "function": "append",
     "args": [
@@ -207,6 +327,48 @@
     ],
     "template": "{{ join \",\" (append (list \"a\" \"b\") \"c\") }}",
     "expected": "a,b,c"
+  },
+  {
+    "name": "prepend-basic",
+    "function": "prepend",
+    "args": [
+      [
+        2,
+        3
+      ],
+      1
+    ],
+    "template": "{{ toJson (prepend (list 2 3) 1) }}",
+    "expected": "[1,2,3]"
+  },
+  {
+    "name": "concat-basic",
+    "function": "concat",
+    "args": [
+      [
+        1,
+        2
+      ],
+      [
+        3,
+        4
+      ]
+    ],
+    "template": "{{ toJson (concat (list 1 2) (list 3 4)) }}",
+    "expected": "[1,2,3,4]"
+  },
+  {
+    "name": "reverse-basic",
+    "function": "reverse",
+    "args": [
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "template": "{{ toJson (reverse (list 1 2 3)) }}",
+    "expected": "[3,2,1]"
   },
   {
     "name": "uniq-basic",
@@ -248,6 +410,18 @@
     "expected": "{\"foo\":\"bar\"}"
   },
   {
+    "name": "mustfromjson-roundtrip",
+    "function": "mustFromJson",
+    "args": [
+      "{\"foo\":\"bar\"}"
+    ],
+    "template": "{{ mustFromJson .json | toJson }}",
+    "data": {
+      "json": "{\"foo\":\"bar\"}"
+    },
+    "expected": "{\"foo\":\"bar\"}"
+  },
+  {
     "name": "tojson-object",
     "function": "toJson",
     "args": [
@@ -262,6 +436,82 @@
       }
     },
     "expected": "{\"foo\":\"bar\"}"
+  },
+  {
+    "name": "toprettyjson-object",
+    "function": "toPrettyJson",
+    "args": [
+      {
+        "foo": "bar"
+      }
+    ],
+    "template": "{{ toPrettyJson .value }}",
+    "data": {
+      "value": {
+        "foo": "bar"
+      }
+    },
+    "expected": "{\n  \"foo\": \"bar\"\n}"
+  },
+  {
+    "name": "musttoprettyjson-object",
+    "function": "mustToPrettyJson",
+    "args": [
+      {
+        "foo": "bar"
+      }
+    ],
+    "template": "{{ mustToPrettyJson .value }}",
+    "data": {
+      "value": {
+        "foo": "bar"
+      }
+    },
+    "expected": "{\n  \"foo\": \"bar\"\n}"
+  },
+  {
+    "name": "torawjson-object",
+    "function": "toRawJson",
+    "args": [
+      {
+        "foo": "bar",
+        "nested": {
+          "baz": 1
+        }
+      }
+    ],
+    "template": "{{ toRawJson .value }}",
+    "data": {
+      "value": {
+        "foo": "bar",
+        "nested": {
+          "baz": 1
+        }
+      }
+    },
+    "expected": "{\"foo\":\"bar\",\"nested\":{\"baz\":1}}"
+  },
+  {
+    "name": "musttorawjson-object",
+    "function": "mustToRawJson",
+    "args": [
+      {
+        "foo": "bar",
+        "nested": {
+          "baz": 1
+        }
+      }
+    ],
+    "template": "{{ mustToRawJson .value }}",
+    "data": {
+      "value": {
+        "foo": "bar",
+        "nested": {
+          "baz": 1
+        }
+      }
+    },
+    "expected": "{\"foo\":\"bar\",\"nested\":{\"baz\":1}}"
   },
   {
     "name": "substr-basic",
@@ -303,6 +553,25 @@
     ],
     "template": "{{ indent 2 \"line1\\nline2\" }}",
     "expected": "  line1\n  line2"
+  },
+  {
+    "name": "nindent-basic",
+    "function": "nindent",
+    "args": [
+      2,
+      "line1\nline2"
+    ],
+    "template": "{{ nindent 2 \"line1\\nline2\" }}",
+    "expected": "\n  line1\n  line2"
+  },
+  {
+    "name": "nospace-basic",
+    "function": "nospace",
+    "args": [
+      " spaced \n text "
+    ],
+    "template": "{{ nospace (printf \" spaced %s text \" \"\\n\") }}",
+    "expected": "spacedtext"
   },
   {
     "name": "compact-basic",


### PR DESCRIPTION
## Summary
- add coverage fixtures for previously untested sprig helpers, including flow, string, slice, and list utilities
- update `splitn` to mirror Go's argument order and map return type and refresh its unit test
- align `prepend` semantics with the Go implementation and adjust fixtures accordingly

## Testing
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_69077bfb3c608325a742022ce942aa2a