### PR TITLE
fix: Restrict Scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:


### PR DESCRIPTION
## Why
- set the Scorecard workflow's default permissions to read-only to comply with the action's workflow verification requirements
- scope the required security-events and id-token write permissions to the analysis job

## Additional Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_69077eefa4ec8325a6b35b7bae1bca53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated permissions configuration in automated workflow processes to optimize security handling across job execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->